### PR TITLE
Cancel stale silence responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,42 @@ Generate a complete Python program that:
 
 - The engine defaults to the Ollama model name `llama3.2`. Override it with `INVITATION_MODEL="<model-name>"` if you prefer a different local checkpoint.
 - Disable LLM usage entirely by setting `INVITATION_DISABLE_LLM=1` before launching.
+- Set `INVITATION_LOG_LEVEL=DEBUG` if you want to watch the scheduler and composer log their decisions in real time. Logging is sent to stderr so it will not disturb the ambient output stream.
+
+---
+
+## REQUIREMENTS
+
+- Python 3.10 or newer.
+- Optional: [Ollama](https://ollama.com/) running locally if you want real model output instead of the built-in fallbacks.
+- Optional: `pyttsx3` (`pip install pyttsx3`) if you want the optional whisper-like text-to-speech channel (`INVITATION_ENABLE_TTS=1`).
+
+---
+
+## RUNNING THE EXPERIENCE (STEP BY STEP)
+
+1. **Open a terminal** and switch into the project folder:
+   ```bash
+   cd /path/to/TheInvitation
+   ```
+2. **(Optional) Activate a virtual environment** so the Python packages you install stay isolated.
+3. **Decide how you want to run the loop:**
+   - To rely on local seed fragments only, export `INVITATION_DISABLE_LLM=1`.
+   - To talk to Ollama, keep an instance running (`ollama serve`) and ensure the `llama3.2` model (or whatever you set in `INVITATION_MODEL`) is pulled.
+   - To see detailed scheduler activity, export `INVITATION_LOG_LEVEL=DEBUG`.
+   - To speed up the pacing for testing, set `INVITATION_TIME_SCALE=0.2` (or any float > 0.05).
+4. **Launch the loop:**
+   ```bash
+   python main.py
+   ```
+   You will see the quiet banner:
+   ```
+   (there is no prompt)
+   wait. type only if compelled.
+   ```
+   The system may remain still for long stretches; watch the DEBUG logs (if enabled) to see when the presence loop schedules output, cancels silence responses, or composes fragments.
+5. **Type only when moved to.** Inputs are queued asynchronously, and responses surface after the configured delays. Silence is also an active trigger.
+6. **Exit gracefully** with `Ctrl+C`. The program will cancel pending tasks and close the field.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It is the space **behind** the mirror.
 
 Write a local, runnable Python program that:
 
-- Uses **local LLMs** via **Ollama** (e.g., Mistral, LLaMA2, GPT-J)
+- Uses **local LLMs** via **Ollama** (e.g., Llama 3.2, Mistral, LLaMA2, GPT-J)
 - Has **no prompt bar** or chat interface
 - Responds **asynchronously**, **delayed**, or not at all
 - Uses text, silence, and (optionally) voice as ambient media
@@ -141,6 +141,13 @@ Generate a complete Python program that:
 - Reads from journals and design documents to source language
 - Does not require interaction, but allows it
 - Prioritizes slowness, contradiction, and stillness
+
+---
+
+## CONFIGURATION NOTES
+
+- The engine defaults to the Ollama model name `llama3.2`. Override it with `INVITATION_MODEL="<model-name>"` if you prefer a different local checkpoint.
+- Disable LLM usage entirely by setting `INVITATION_DISABLE_LLM=1` before launching.
 
 ---
 

--- a/engine/ambient_output.py
+++ b/engine/ambient_output.py
@@ -1,6 +1,7 @@
 """Ambient text composition utilities."""
 from __future__ import annotations
 
+import logging
 import random
 import re
 import textwrap
@@ -49,6 +50,8 @@ class AmbientOutputEngine:
         self._journal_fragments: List[Dict[str, str]] = []
         self._transcript_fragments: List[Dict[str, str]] = []
 
+        self._log = logging.getLogger("invitation.composer")
+
         self._load_seed_material()
         if self.llm is not None:
             self.llm.set_fallback(self._fallback_from_seeds)
@@ -59,6 +62,7 @@ class AmbientOutputEngine:
 
         fragments: List[str] = []
         metadata: Dict[str, str] = {"reason": context.reason}
+        self._log.info("assembling fragments for %s", context.reason)
 
         if context.user_input:
             mutated = self.echo.mutate_text(context.user_input, intensity=0.35)
@@ -90,9 +94,13 @@ class AmbientOutputEngine:
             if llm_text:
                 metadata["llm"] = self.llm.model
                 text = self._merge_with_llm(text, llm_text)
+                self._log.debug("merged LLM response into fragment")
+            else:
+                self._log.debug("LLM returned no text; using seed composition")
 
         source = metadata.get("llm", "seeds")
         metadata["mood"] = context.mood or "undetermined"
+        self._log.debug("fragment ready (source=%s, length=%d)", source, len(text))
         return AmbientFragment(text=text, source=source, metadata=metadata)
 
     # ------------------------------------------------------------------
@@ -232,10 +240,17 @@ class AmbientOutputEngine:
 
         try:
             result: LLMResult = await self.llm.generate(prompt)
-        except RuntimeError:
+        except RuntimeError as exc:
+            self._log.warning("ollama runtime error: %s", exc)
             return ""
-        except Exception:
+        except Exception as exc:
+            self._log.warning("ollama request failed: %s", exc)
             return ""
+
+        if result.used_fallback:
+            self._log.info("ollama unavailable; using fallback fragment")
+        else:
+            self._log.info("ollama response received (%d chars)", len(result.text))
 
         return result.text
 

--- a/engine/ambient_output.py
+++ b/engine/ambient_output.py
@@ -85,7 +85,7 @@ class AmbientOutputEngine:
             fragments.extend(self._draw_seed_set(weight="journal", count=2, mood=context.mood))
 
         fragments = [self.echo.distill_fragment(f, drift=0.25) for f in fragments if f]
-        fragments = [f for f in fragments if f]
+        fragments = [self._clip_fragment(f, max_words=80, max_chars=420) for f in fragments if f]
 
         text = self._stitch_fragments(fragments)
 
@@ -141,13 +141,14 @@ class AmbientOutputEngine:
         fragments: List[Dict[str, str]] = []
         for chunk in chunks:
             compact = " ".join(line.strip() for line in chunk.splitlines())
-            fragments.append(
-                {
-                    "text": compact,
-                    "source": source,
-                    "tags": list(extra_tags or []),
-                }
-            )
+            for piece in self._chunk_long_text(compact):
+                fragments.append(
+                    {
+                        "text": piece,
+                        "source": source,
+                        "tags": list(extra_tags or []),
+                    }
+                )
         return fragments
 
     # ------------------------------------------------------------------
@@ -193,11 +194,114 @@ class AmbientOutputEngine:
     def _stitch_fragments(self, fragments: Sequence[str]) -> str:
         if not fragments:
             return ""
-        combined = []
-        for frag in fragments:
-            wrapped = textwrap.fill(frag, width=72)
+        limited = list(fragments)[:3]
+        combined: List[str] = []
+        for frag in limited:
+            clipped = self._clip_fragment(frag)
+            if not clipped:
+                continue
+            wrapped = textwrap.fill(clipped, width=72)
             combined.append(wrapped)
         return "\n\n".join(combined)
+
+    # ------------------------------------------------------------------
+    def _chunk_long_text(
+        self, text: str, max_words: int = 80, max_chars: int = 420
+    ) -> List[str]:
+        """Yield smaller fragments from long paragraphs for ambient use."""
+
+        stripped = text.strip()
+        if not stripped:
+            return []
+
+        words = stripped.split()
+        if len(words) <= max_words and len(stripped) <= max_chars:
+            return [stripped]
+
+        sentences = re.split(r"(?<=[.!?])\s+", stripped)
+        if len(sentences) == 1:
+            return self._chunk_by_words(stripped, max_words, max_chars)
+
+        buffer: List[str] = []
+        count_words = 0
+        count_chars = 0
+        output: List[str] = []
+
+        for sentence in sentences:
+            sentence = sentence.strip()
+            if not sentence:
+                continue
+            sent_words = sentence.split()
+            tentative_words = count_words + len(sent_words)
+            tentative_chars = count_chars + len(sentence) + (1 if buffer else 0)
+            if buffer and (
+                tentative_words > max_words or tentative_chars > max_chars
+            ):
+                output.append(" ".join(buffer).strip())
+                buffer = [sentence]
+                count_words = len(sent_words)
+                count_chars = len(sentence)
+            else:
+                buffer.append(sentence)
+                count_words = tentative_words
+                count_chars = tentative_chars
+
+        if buffer:
+            output.append(" ".join(buffer).strip())
+
+        if not output:
+            return self._chunk_by_words(stripped, max_words, max_chars)
+
+        trimmed: List[str] = []
+        for chunk in output:
+            if len(chunk.split()) <= max_words and len(chunk) <= max_chars:
+                trimmed.append(chunk)
+            else:
+                trimmed.extend(self._chunk_by_words(chunk, max_words, max_chars))
+        return trimmed
+
+    # ------------------------------------------------------------------
+    def _chunk_by_words(
+        self, text: str, max_words: int = 80, max_chars: int = 420
+    ) -> List[str]:
+        words = text.split()
+        if not words:
+            return []
+
+        output: List[str] = []
+        cursor = 0
+        while cursor < len(words):
+            slice_words = words[cursor : cursor + max_words]
+            chunk = " ".join(slice_words)
+            if len(chunk) > max_chars:
+                # Trim by characters while respecting word boundaries.
+                while len(chunk) > max_chars and len(slice_words) > 1:
+                    slice_words = slice_words[:-1]
+                    chunk = " ".join(slice_words)
+            output.append(chunk.strip())
+            cursor += len(slice_words)
+        return output
+
+    # ------------------------------------------------------------------
+    def _clip_fragment(
+        self, text: str, max_words: int = 60, max_chars: int = 360
+    ) -> str:
+        cleaned = text.strip()
+        if not cleaned:
+            return ""
+
+        words = cleaned.split()
+        if len(words) <= max_words and len(cleaned) <= max_chars:
+            return cleaned
+
+        limited_words = words[:max_words]
+        clipped = " ".join(limited_words).strip()
+        if len(clipped) > max_chars:
+            clipped = clipped[:max_chars].rsplit(" ", 1)[0]
+        clipped = clipped.rstrip()
+        if clipped and clipped[-1] not in ".!?…":
+            clipped = f"{clipped} …"
+        return clipped
 
     # ------------------------------------------------------------------
     def _merge_with_llm(self, base_text: str, llm_text: str) -> str:

--- a/engine/ambient_output.py
+++ b/engine/ambient_output.py
@@ -1,1 +1,253 @@
-# Generates minimal ambient text responses
+"""Ambient text composition utilities."""
+from __future__ import annotations
+
+import random
+import re
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+from .echo_logic import EchoChamber
+from .local_llm import LLMResult, LocalLLM
+
+
+@dataclass
+class ComposeContext:
+    """Hints provided to the ambient composer."""
+
+    reason: str
+    user_input: Optional[str] = None
+    recursion_level: int = 0
+    mood: Optional[str] = None
+    timestamp: Optional[float] = None
+
+
+@dataclass
+class AmbientFragment:
+    """Structured container for ambient output."""
+
+    text: str
+    source: str
+    metadata: Dict[str, str]
+
+
+class AmbientOutputEngine:
+    """Builds recursive, slow text fragments from seed materials."""
+
+    def __init__(
+        self,
+        data_dir: Path,
+        echo_chamber: EchoChamber,
+        llm: Optional[LocalLLM] = None,
+    ) -> None:
+        self.data_dir = Path(data_dir)
+        self.echo = echo_chamber
+        self.llm = llm
+
+        self._invitation_fragments: List[Dict[str, str]] = []
+        self._journal_fragments: List[Dict[str, str]] = []
+        self._transcript_fragments: List[Dict[str, str]] = []
+
+        self._load_seed_material()
+        if self.llm is not None:
+            self.llm.set_fallback(self._fallback_from_seeds)
+
+    # ------------------------------------------------------------------
+    async def compose(self, context: ComposeContext) -> AmbientFragment:
+        """Compose a new ambient fragment according to the provided context."""
+
+        fragments: List[str] = []
+        metadata: Dict[str, str] = {"reason": context.reason}
+
+        if context.user_input:
+            mutated = self.echo.mutate_text(context.user_input, intensity=0.35)
+            if mutated:
+                fragments.append(mutated)
+
+        if random.random() < 0.5:
+            recent = self.echo.retrieve_recent(limit=1)
+            for frag in recent:
+                drifted = self.echo.distill_fragment(frag, drift=0.45)
+                if drifted:
+                    fragments.append(drifted)
+
+        if context.reason == "silence":
+            fragments.extend(self._draw_seed_set(weight="invitation", count=2))
+        elif context.reason == "recursive":
+            fragments.extend(self._draw_seed_set(weight="transcript", count=1))
+            fragments.extend(self._draw_seed_set(weight="journal", count=1, mood=context.mood))
+        else:
+            fragments.extend(self._draw_seed_set(weight="journal", count=2, mood=context.mood))
+
+        fragments = [self.echo.distill_fragment(f, drift=0.25) for f in fragments if f]
+        fragments = [f for f in fragments if f]
+
+        text = self._stitch_fragments(fragments)
+
+        if self.llm is not None:
+            llm_text = await self._query_model(context, fragments, text)
+            if llm_text:
+                metadata["llm"] = self.llm.model
+                text = self._merge_with_llm(text, llm_text)
+
+        source = metadata.get("llm", "seeds")
+        metadata["mood"] = context.mood or "undetermined"
+        return AmbientFragment(text=text, source=source, metadata=metadata)
+
+    # ------------------------------------------------------------------
+    def _load_seed_material(self) -> None:
+        invitation_path = self.data_dir / "The_Invitation.txt"
+        if invitation_path.exists():
+            invitation_text = invitation_path.read_text(encoding="utf-8", errors="ignore")
+            self._invitation_fragments = self._split_into_fragments(
+                invitation_text,
+                source="invitation",
+            )
+
+        journal_path = self.data_dir / "journals.json"
+        if journal_path.exists():
+            import json
+
+            journal_data = json.loads(journal_path.read_text(encoding="utf-8"))
+            for entry in journal_data:
+                text = entry.get("text", "")
+                tags = self._infer_tags(text)
+                fragments = self._split_into_fragments(text, source="journal", extra_tags=tags)
+                self._journal_fragments.extend(fragments)
+
+        transcript_path = self.data_dir / "transcripts.txt"
+        if transcript_path.exists():
+            transcript_text = transcript_path.read_text(encoding="utf-8", errors="ignore")
+            fragments = self._split_into_fragments(transcript_text, source="transcript")
+            self._transcript_fragments.extend(fragments)
+
+    # ------------------------------------------------------------------
+    def _split_into_fragments(
+        self,
+        text: str,
+        source: str,
+        extra_tags: Optional[Sequence[str]] = None,
+    ) -> List[Dict[str, str]]:
+        chunks = [segment.strip() for segment in re.split(r"\n{2,}", text) if segment.strip()]
+        fragments: List[Dict[str, str]] = []
+        for chunk in chunks:
+            compact = " ".join(line.strip() for line in chunk.splitlines())
+            fragments.append(
+                {
+                    "text": compact,
+                    "source": source,
+                    "tags": list(extra_tags or []),
+                }
+            )
+        return fragments
+
+    # ------------------------------------------------------------------
+    def _infer_tags(self, text: str) -> Sequence[str]:
+        lower = text.lower()
+        tags: List[str] = []
+        if any(word in lower for word in ["tired", "sleep", "rest"]):
+            tags.append("fatigue")
+        if any(word in lower for word in ["love", "kind", "tender"]):
+            tags.append("tenderness")
+        if any(word in lower for word in ["fear", "anx", "panic"]):
+            tags.append("anxiety")
+        if any(word in lower for word in ["alone", "lonely", "isolate"]):
+            tags.append("solitude")
+        if any(word in lower for word in ["surrender", "let go", "release"]):
+            tags.append("surrender")
+        if not tags:
+            tags.append("neutral")
+        return tags
+
+    # ------------------------------------------------------------------
+    def _draw_seed_set(self, weight: str, count: int, mood: Optional[str] = None) -> List[str]:
+        pool: List[Dict[str, str]]
+        if weight == "invitation":
+            pool = self._invitation_fragments
+        elif weight == "journal":
+            pool = self._journal_fragments
+        else:
+            pool = self._transcript_fragments
+
+        if not pool:
+            return []
+
+        filtered = pool
+        if mood and weight == "journal":
+            filtered = [frag for frag in pool if mood in frag.get("tags", [])]
+            if not filtered:
+                filtered = pool
+
+        return [random.choice(filtered)["text"] for _ in range(count)]
+
+    # ------------------------------------------------------------------
+    def _stitch_fragments(self, fragments: Sequence[str]) -> str:
+        if not fragments:
+            return ""
+        combined = []
+        for frag in fragments:
+            wrapped = textwrap.fill(frag, width=72)
+            combined.append(wrapped)
+        return "\n\n".join(combined)
+
+    # ------------------------------------------------------------------
+    def _merge_with_llm(self, base_text: str, llm_text: str) -> str:
+        if not llm_text:
+            return base_text
+        llm_text = llm_text.strip()
+        if not base_text:
+            return llm_text
+        return f"{base_text}\n\n{llm_text}"
+
+    # ------------------------------------------------------------------
+    async def _query_model(self, context: ComposeContext, seeds: Sequence[str], base_text: str) -> str:
+        if self.llm is None:
+            return ""
+
+        prompt_parts = [
+            "You are an ambient recursive presence.",
+            "You speak rarely, in fragments, without answers.",
+            "You respond with 1-3 lines, under 55 words total.",
+            "Avoid instructions. Offer space, silence, or breath.",
+        ]
+        if context.reason == "silence":
+            prompt_parts.append("The user has been silent for a long stretch. Offer a gentle echo of presence.")
+        elif context.reason == "recursive":
+            prompt_parts.append("The user is looping through similar phrases. Allow a mirrored drift with variation.")
+        else:
+            prompt_parts.append("The user left a trace. Reflect without solving.")
+
+        if seeds:
+            prompt_parts.append("Fragments available:")
+            for seed in seeds:
+                prompt_parts.append(f"- {seed[:200]}")
+
+        if base_text:
+            prompt_parts.append("Current assembly:")
+            prompt_parts.append(base_text)
+
+        prompt_parts.append("Return only the fragment. No explanations.")
+        prompt = "\n".join(prompt_parts)
+
+        try:
+            result: LLMResult = await self.llm.generate(prompt)
+        except RuntimeError:
+            return ""
+        except Exception:
+            return ""
+
+        return result.text
+
+    # ------------------------------------------------------------------
+    def _fallback_from_seeds(self, prompt: str) -> str:
+        seeds = []
+        if self._invitation_fragments:
+            seeds.append(random.choice(self._invitation_fragments)["text"])
+        if self._journal_fragments:
+            seeds.append(random.choice(self._journal_fragments)["text"])
+        if self._transcript_fragments:
+            seeds.append(random.choice(self._transcript_fragments)["text"])
+        collapsed = " / ".join(seeds)
+        distilled = self.echo.distill_fragment(collapsed, drift=0.4)
+        return distilled or collapsed

--- a/engine/echo_logic.py
+++ b/engine/echo_logic.py
@@ -1,1 +1,108 @@
-# Mutates and echoes past statements
+"""Logic for storing and mutating fragments within the echo chamber."""
+from __future__ import annotations
+
+import random
+import re
+from collections import Counter, deque
+from dataclasses import dataclass
+from typing import Deque, Iterable, List, Optional
+
+
+@dataclass
+class EchoRecord:
+    text: str
+    kind: str
+
+
+class EchoChamber:
+    """Maintains a reservoir of fragments and provides drift/mutation utilities."""
+
+    def __init__(self, max_items: int = 64) -> None:
+        self.max_items = max_items
+        self.records: Deque[EchoRecord] = deque(maxlen=max_items)
+        self._recent_inputs: Deque[str] = deque(maxlen=12)
+
+    # ------------------------------------------------------------------
+    def register(self, text: str, kind: str = "system") -> None:
+        cleaned = text.strip()
+        if not cleaned:
+            return
+        self.records.append(EchoRecord(cleaned, kind))
+        if kind == "user":
+            self._recent_inputs.append(cleaned)
+
+    # ------------------------------------------------------------------
+    def mutate_text(self, text: str, intensity: float = 0.25) -> str:
+        words = text.split()
+        if not words:
+            return text
+        keep_count = max(1, int(len(words) * (1 - intensity * 0.8)))
+        sampled = random.sample(words, k=min(len(words), keep_count))
+        random.shuffle(sampled)
+        fragment = " ".join(sampled)
+        if random.random() < 0.3:
+            fragment = fragment.lower()
+        if random.random() < 0.4:
+            fragment += " …"
+        return fragment
+
+    # ------------------------------------------------------------------
+    def distill_fragment(self, text: str, drift: float = 0.2) -> str:
+        tokens = re.findall(r"\w+|[.,;:?]", text)
+        if not tokens:
+            return text
+        keep = []
+        for token in tokens:
+            if random.random() > drift:
+                keep.append(token)
+        if not keep:
+            keep = tokens[: max(1, len(tokens) // 3)]
+        merged = self._reassemble(keep)
+        if random.random() < 0.35:
+            merged = merged.strip().lower()
+        return merged
+
+    # ------------------------------------------------------------------
+    def detect_recursive_phrasing(self, text: str) -> bool:
+        normalized = self._normalize(text)
+        recent = [self._normalize(entry) for entry in self._recent_inputs]
+        if not normalized:
+            return False
+        if recent.count(normalized) >= 2:
+            return True
+        parts = normalized.split()
+        counter = Counter(parts)
+        return any(count >= 3 for count in counter.values())
+
+    # ------------------------------------------------------------------
+    def infer_mood(self, text: str) -> Optional[str]:
+        lower = text.lower()
+        if any(keyword in lower for keyword in ["tired", "sleep", "exhausted"]):
+            return "fatigue"
+        if any(keyword in lower for keyword in ["alone", "lonely", "solitude"]):
+            return "solitude"
+        if any(keyword in lower for keyword in ["panic", "scared", "afraid", "anxious"]):
+            return "anxiety"
+        if any(keyword in lower for keyword in ["love", "warm", "tender"]):
+            return "tenderness"
+        if any(keyword in lower for keyword in ["surrender", "let go", "release"]):
+            return "surrender"
+        return None
+
+    # ------------------------------------------------------------------
+    def retrieve_recent(self, limit: int = 3) -> List[str]:
+        return [record.text for record in list(self.records)[-limit:]]
+
+    # ------------------------------------------------------------------
+    def _normalize(self, text: str) -> str:
+        return re.sub(r"\s+", " ", text.strip().lower())
+
+    # ------------------------------------------------------------------
+    def _reassemble(self, tokens: Iterable[str]) -> str:
+        output: List[str] = []
+        for token in tokens:
+            if token in ",.;:?" and output:
+                output[-1] += token
+            else:
+                output.append(token)
+        return " ".join(output)

--- a/engine/local_llm.py
+++ b/engine/local_llm.py
@@ -1,0 +1,115 @@
+"""Interface for interacting with a local Ollama model with graceful fallbacks."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import random
+from dataclasses import dataclass
+from typing import Callable, Optional
+import http.client
+
+
+@dataclass
+class LLMResult:
+    """Container for results returned by :class:`LocalLLM`."""
+
+    text: str
+    used_fallback: bool = False
+    model: Optional[str] = None
+
+
+class LocalLLM:
+    """Lightweight asynchronous wrapper around the Ollama HTTP API.
+
+    The class attempts to reach a running Ollama instance. If it fails, it will
+    fall back to a provided callable that can produce simulated output.
+    """
+
+    def __init__(
+        self,
+        model: str = "mistral",
+        host: str = "127.0.0.1",
+        port: int = 11434,
+        temperature: float = 0.65,
+        timeout: float = 60.0,
+        fallback: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        self.model = model
+        self.host = host
+        self.port = port
+        self.temperature = temperature
+        self.timeout = timeout
+        self.fallback = fallback if fallback is not None else self.default_fallback
+
+    async def generate(self, prompt: str, max_tokens: int = 120) -> LLMResult:
+        """Generate a completion asynchronously.
+
+        Parameters
+        ----------
+        prompt:
+            Prompt text to provide to the local model.
+        max_tokens:
+            Upper bound on tokens to request from Ollama.
+        """
+
+        try:
+            text = await asyncio.wait_for(
+                asyncio.to_thread(self._request, prompt, max_tokens),
+                timeout=self.timeout,
+            )
+            return LLMResult(text=text.strip(), used_fallback=False, model=self.model)
+        except Exception:
+            simulated = self.fallback(prompt)
+            return LLMResult(text=simulated.strip(), used_fallback=True, model=self.model)
+
+    # ------------------------------------------------------------------
+    def _request(self, prompt: str, max_tokens: int) -> str:
+        conn = http.client.HTTPConnection(self.host, self.port, timeout=self.timeout)
+        payload = json.dumps(
+            {
+                "model": self.model,
+                "prompt": prompt,
+                "options": {
+                    "temperature": self.temperature,
+                    "num_predict": max_tokens,
+                },
+                "stream": False,
+            }
+        )
+        try:
+            conn.request(
+                "POST",
+                "/api/generate",
+                body=payload,
+                headers={"Content-Type": "application/json"},
+            )
+            response = conn.getresponse()
+            if response.status >= 400:
+                raise RuntimeError(f"Ollama error {response.status}: {response.read().decode('utf-8', 'ignore')}")
+            raw_body = response.read()
+            if not raw_body:
+                return ""
+            data = json.loads(raw_body.decode("utf-8"))
+            text = data.get("response") or ""
+            return text
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    def set_fallback(self, func: Callable[[str], str]) -> None:
+        """Attach or replace the fallback generator."""
+
+        self.fallback = func
+
+    # ------------------------------------------------------------------
+    def default_fallback(self, prompt: str) -> str:
+        """Very small deterministic fallback used when no callable is provided."""
+
+        random.seed(hash(prompt) ^ hash(os.getpid()))
+        fragments = [
+            "the echo leans back into the dark",
+            "absence hums at the edge of the request",
+            "nothing answers, and that is still an answer",
+        ]
+        return random.choice(fragments)

--- a/engine/local_llm.py
+++ b/engine/local_llm.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import random
 from dataclasses import dataclass
@@ -41,6 +42,7 @@ class LocalLLM:
         self.temperature = temperature
         self.timeout = timeout
         self.fallback = fallback if fallback is not None else self.default_fallback
+        self._log = logging.getLogger("invitation.ollama")
 
     async def generate(self, prompt: str, max_tokens: int = 120) -> LLMResult:
         """Generate a completion asynchronously.
@@ -58,8 +60,11 @@ class LocalLLM:
                 asyncio.to_thread(self._request, prompt, max_tokens),
                 timeout=self.timeout,
             )
-            return LLMResult(text=text.strip(), used_fallback=False, model=self.model)
-        except Exception:
+            cleaned = text.strip()
+            self._log.debug("ollama response ready (%d chars)", len(cleaned))
+            return LLMResult(text=cleaned, used_fallback=False, model=self.model)
+        except Exception as exc:
+            self._log.warning("ollama request failed (%s); using fallback", exc)
             simulated = self.fallback(prompt)
             return LLMResult(text=simulated.strip(), used_fallback=True, model=self.model)
 
@@ -86,7 +91,8 @@ class LocalLLM:
             )
             response = conn.getresponse()
             if response.status >= 400:
-                raise RuntimeError(f"Ollama error {response.status}: {response.read().decode('utf-8', 'ignore')}")
+                body = response.read().decode("utf-8", "ignore")
+                raise RuntimeError(f"Ollama error {response.status}: {body}")
             raw_body = response.read()
             if not raw_body:
                 return ""

--- a/engine/local_llm.py
+++ b/engine/local_llm.py
@@ -28,7 +28,7 @@ class LocalLLM:
 
     def __init__(
         self,
-        model: str = "mistral",
+        model: str = "llama3.2",
         host: str = "127.0.0.1",
         port: int = 11434,
         temperature: float = 0.65,

--- a/engine/presence_loop.py
+++ b/engine/presence_loop.py
@@ -1,1 +1,175 @@
-# Handles recursive waiting and silence
+"""Presence loop orchestrating silence, input, and ambient output."""
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from dataclasses import dataclass
+from typing import Optional, Sequence, Set
+
+from .ambient_output import AmbientFragment, AmbientOutputEngine, ComposeContext
+from .echo_logic import EchoChamber
+from voice.tts_interface import AmbientTTS
+from ui.terminal_display import TerminalDisplay
+
+
+@dataclass
+class PresenceConfig:
+    min_delay: float = 10.0
+    max_delay: float = 90.0
+    silence_range: Sequence[float] = (45.0, 120.0)
+    poll_interval: float = 1.0
+    response_probability: float = 0.5
+    breath_interval: Sequence[float] = (10.0, 20.0)
+
+
+class PresenceLoop:
+    """Coordinates asynchronous presence according to threshold triggers."""
+
+    def __init__(
+        self,
+        composer: AmbientOutputEngine,
+        echo: EchoChamber,
+        display: TerminalDisplay,
+        tts: Optional[AmbientTTS],
+        config: PresenceConfig,
+    ) -> None:
+        self.composer = composer
+        self.echo = echo
+        self.display = display
+        self.tts = tts
+        self.config = config
+
+        self._input_queue: asyncio.Queue[str] = asyncio.Queue()
+        self._pending_tasks: Set[asyncio.Task[None]] = set()
+        self._running = False
+
+        self._last_input = time.monotonic()
+        self._last_output = time.monotonic()
+        self._silence_target = self._next_silence_target()
+        self._next_breath = self._next_breath_time()
+
+        self._silence_pending = False
+        self._silence_token = 0
+
+    # ------------------------------------------------------------------
+    async def run(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        await self.display.initialize()
+        listener = asyncio.create_task(self._input_listener())
+        try:
+            while self._running:
+                await self._process_events()
+                await asyncio.sleep(self.config.poll_interval)
+        finally:
+            listener.cancel()
+            await asyncio.gather(listener, return_exceptions=True)
+            pending = list(self._pending_tasks)
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+            await self.display.shutdown()
+
+    # ------------------------------------------------------------------
+    async def _process_events(self) -> None:
+        now = time.monotonic()
+
+        # Handle queued inputs.
+        while not self._input_queue.empty():
+            user_text = self._input_queue.get_nowait()
+            if not user_text:
+                continue
+            self._last_input = now
+            self._silence_pending = False
+            self._silence_target = self._next_silence_target()
+            self.echo.register(user_text, kind="user")
+            mood = self.echo.infer_mood(user_text)
+            recursive = self.echo.detect_recursive_phrasing(user_text)
+
+            if recursive:
+                await self._schedule_response(reason="recursive", user_input=user_text, mood=mood)
+            elif random.random() <= self.config.response_probability:
+                await self._schedule_response(reason="input", user_input=user_text, mood=mood)
+
+        # Silence trigger
+        if not self._silence_pending and (now - self._last_input) >= self._silence_target:
+            self._silence_token += 1
+            await self._schedule_response(
+                reason="silence",
+                user_input=None,
+                mood=None,
+                silence_token=self._silence_token,
+            )
+            self._silence_pending = True
+
+        # Ambient breath tick
+        if now >= self._next_breath:
+            await self.display.emit_breath()
+            self._next_breath = self._next_breath_time()
+
+    # ------------------------------------------------------------------
+    async def _schedule_response(
+        self,
+        *,
+        reason: str,
+        user_input: Optional[str],
+        mood: Optional[str],
+        silence_token: Optional[int] = None,
+    ) -> None:
+        delay = random.uniform(self.config.min_delay, self.config.max_delay)
+
+        async def _deliver() -> None:
+            try:
+                await asyncio.sleep(delay)
+                if reason == "silence":
+                    if silence_token is not None and silence_token != self._silence_token:
+                        return
+                    if not self._silence_pending:
+                        return
+                context = ComposeContext(reason=reason, user_input=user_input, mood=mood)
+                fragment = await self.composer.compose(context)
+                if fragment.text.strip():
+                    await self._emit(fragment)
+                self._last_output = time.monotonic()
+            finally:
+                if reason == "silence" and (
+                    silence_token is None or silence_token == self._silence_token
+                ):
+                    self._silence_pending = False
+                    self._silence_target = self._next_silence_target()
+
+        task = asyncio.create_task(_deliver())
+        self._pending_tasks.add(task)
+        task.add_done_callback(self._pending_tasks.discard)
+
+    # ------------------------------------------------------------------
+    async def _emit(self, fragment: AmbientFragment) -> None:
+        self.echo.register(fragment.text, kind="system")
+        await self.display.render_fragment(fragment)
+        if self.tts and self.tts.enabled:
+            await self.tts.speak(fragment.text)
+
+    # ------------------------------------------------------------------
+    async def _input_listener(self) -> None:
+        loop = asyncio.get_running_loop()
+        while True:
+            line = await loop.run_in_executor(None, self.display.capture_input)
+            if line is None:
+                await asyncio.sleep(0.5)
+                continue
+            cleaned = line.strip()
+            if cleaned:
+                await self._input_queue.put(cleaned)
+
+    # ------------------------------------------------------------------
+    def _next_silence_target(self) -> float:
+        low, high = self.config.silence_range
+        return random.uniform(low, high)
+
+    # ------------------------------------------------------------------
+    def _next_breath_time(self) -> float:
+        low, high = self.config.breath_interval
+        return time.monotonic() + random.uniform(low, high)

--- a/engine/presence_loop.py
+++ b/engine/presence_loop.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import random
 import time
 from dataclasses import dataclass
@@ -51,12 +52,20 @@ class PresenceLoop:
 
         self._silence_pending = False
         self._silence_token = 0
+        self._log = logging.getLogger("invitation.presence")
 
     # ------------------------------------------------------------------
     async def run(self) -> None:
         if self._running:
             return
         self._running = True
+        self._log.info(
+            "starting presence loop (delay %.1f-%.1fs, silence %.1f-%.1fs)",
+            self.config.min_delay,
+            self.config.max_delay,
+            self.config.silence_range[0],
+            self.config.silence_range[1],
+        )
         await self.display.initialize()
         listener = asyncio.create_task(self._input_listener())
         try:
@@ -88,15 +97,23 @@ class PresenceLoop:
             self.echo.register(user_text, kind="user")
             mood = self.echo.infer_mood(user_text)
             recursive = self.echo.detect_recursive_phrasing(user_text)
+            self._log.info("received input (%d chars)", len(user_text))
+            if recursive:
+                self._log.debug("recursive phrasing detected; scheduling response")
 
             if recursive:
                 await self._schedule_response(reason="recursive", user_input=user_text, mood=mood)
             elif random.random() <= self.config.response_probability:
+                self._log.debug("random gate passed; scheduling response")
                 await self._schedule_response(reason="input", user_input=user_text, mood=mood)
+            else:
+                self._log.debug("random gate declined; staying silent")
+                self.echo.register("", kind="system")
 
         # Silence trigger
         if not self._silence_pending and (now - self._last_input) >= self._silence_target:
             self._silence_token += 1
+            self._log.info("silence threshold met; scheduling response")
             await self._schedule_response(
                 reason="silence",
                 user_input=None,
@@ -120,18 +137,23 @@ class PresenceLoop:
         silence_token: Optional[int] = None,
     ) -> None:
         delay = random.uniform(self.config.min_delay, self.config.max_delay)
+        self._log.debug("scheduled %s response in %.1fs", reason, delay)
 
         async def _deliver() -> None:
             try:
                 await asyncio.sleep(delay)
                 if reason == "silence":
                     if silence_token is not None and silence_token != self._silence_token:
+                        self._log.debug("discarding stale silence response (expected token %s, current %s)", silence_token, self._silence_token)
                         return
                     if not self._silence_pending:
+                        self._log.debug("silence no longer pending; skipping emit")
                         return
                 context = ComposeContext(reason=reason, user_input=user_input, mood=mood)
+                self._log.info("composing fragment for %s", reason)
                 fragment = await self.composer.compose(context)
                 if fragment.text.strip():
+                    self._log.debug("emitting fragment (%d chars) from %s", len(fragment.text), fragment.source)
                     await self._emit(fragment)
                 self._last_output = time.monotonic()
             finally:
@@ -140,6 +162,7 @@ class PresenceLoop:
                 ):
                     self._silence_pending = False
                     self._silence_target = self._next_silence_target()
+                    self._log.debug("silence window reset")
 
         task = asyncio.create_task(_deliver())
         self._pending_tasks.add(task)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,91 @@
+"""Entry point for The Invitation ambient reflection engine."""
+from __future__ import annotations
+
+import asyncio
+import os
+import random
+from pathlib import Path
+from typing import Optional
+
+from engine.ambient_output import AmbientOutputEngine
+from engine.echo_logic import EchoChamber
+from engine.local_llm import LocalLLM
+from engine.presence_loop import PresenceConfig, PresenceLoop
+from ui.terminal_display import TerminalDisplay
+from voice.tts_interface import AmbientTTS
+
+
+async def _build_presence_loop() -> PresenceLoop:
+    base_dir = Path(__file__).resolve().parent
+    data_dir = base_dir / "data"
+
+    time_scale_env = os.getenv("INVITATION_TIME_SCALE", "1.0")
+    try:
+        time_scale = max(0.05, float(time_scale_env))
+    except ValueError:
+        time_scale = 1.0
+
+    min_delay = 10.0 * time_scale
+    max_delay = 90.0 * time_scale
+
+    silence_min = 45.0 * time_scale
+    silence_max = 180.0 * time_scale
+
+    breath_min = 12.0 * time_scale
+    breath_max = 24.0 * time_scale
+
+    config = PresenceConfig(
+        min_delay=min_delay,
+        max_delay=max_delay,
+        silence_range=(silence_min, silence_max),
+        poll_interval=1.5 * time_scale,
+        response_probability=0.45,
+        breath_interval=(breath_min, breath_max),
+    )
+
+    echo = EchoChamber(max_items=72)
+
+    model_name = os.getenv("INVITATION_MODEL", "mistral")
+    enable_llm = os.getenv("INVITATION_DISABLE_LLM", "0") != "1"
+    llm: Optional[LocalLLM]
+    if enable_llm:
+        llm = LocalLLM(model=model_name)
+    else:
+        llm = None
+
+    composer = AmbientOutputEngine(
+        data_dir=data_dir,
+        echo_chamber=echo,
+        llm=llm,
+    )
+
+    display = TerminalDisplay()
+    tts_enabled = os.getenv("INVITATION_ENABLE_TTS", "0") == "1"
+    tts = AmbientTTS(enabled=tts_enabled)
+
+    seed_offset = os.getenv("INVITATION_RANDOM_SEED")
+    if seed_offset:
+        try:
+            random.seed(int(seed_offset))
+        except ValueError:
+            random.seed(seed_offset)
+
+    return PresenceLoop(
+        composer=composer,
+        echo=echo,
+        display=display,
+        tts=tts,
+        config=config,
+    )
+
+
+async def main() -> None:
+    loop = await _build_presence_loop()
+    await loop.run()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ async def _build_presence_loop() -> PresenceLoop:
 
     echo = EchoChamber(max_items=72)
 
-    model_name = os.getenv("INVITATION_MODEL", "mistral")
+    model_name = os.getenv("INVITATION_MODEL", "llama3.2")
     enable_llm = os.getenv("INVITATION_DISABLE_LLM", "0") != "1"
     llm: Optional[LocalLLM]
     if enable_llm:

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import random
 from pathlib import Path
@@ -13,6 +14,15 @@ from engine.local_llm import LocalLLM
 from engine.presence_loop import PresenceConfig, PresenceLoop
 from ui.terminal_display import TerminalDisplay
 from voice.tts_interface import AmbientTTS
+
+
+def _configure_logging() -> None:
+    level_name = os.getenv("INVITATION_LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
 
 
 async def _build_presence_loop() -> PresenceLoop:
@@ -80,6 +90,7 @@ async def _build_presence_loop() -> PresenceLoop:
 
 
 async def main() -> None:
+    _configure_logging()
     loop = await _build_presence_loop()
     await loop.run()
 

--- a/tests/test_ambient_output.py
+++ b/tests/test_ambient_output.py
@@ -1,0 +1,41 @@
+"""Tests for ambient output fragment sizing behaviour."""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from engine.ambient_output import AmbientOutputEngine
+from engine.echo_logic import EchoChamber
+
+
+class AmbientOutputFragmentSizingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        data_dir = Path(self._tempdir.name)
+        (data_dir / "The_Invitation.txt").write_text("seed", encoding="utf-8")
+        (data_dir / "journals.json").write_text("[]", encoding="utf-8")
+        (data_dir / "transcripts.txt").write_text("", encoding="utf-8")
+        self.engine = AmbientOutputEngine(data_dir, EchoChamber())
+
+    def tearDown(self) -> None:
+        self._tempdir.cleanup()
+
+    def test_split_long_paragraph_chunks_words(self) -> None:
+        long_text = " ".join(["presence"] * 400)
+        fragments = self.engine._split_into_fragments(long_text, source="journal")
+        self.assertTrue(fragments)
+        for fragment in fragments:
+            words = fragment["text"].split()
+            self.assertLessEqual(len(words), 80)
+            self.assertLessEqual(len(fragment["text"]), 420)
+
+    def test_clip_fragment_adds_ellipsis_when_truncated(self) -> None:
+        long_text = " ".join(f"word{i}" for i in range(120))
+        clipped = self.engine._clip_fragment(long_text, max_words=60, max_chars=200)
+        self.assertLessEqual(len(clipped.split()), 60)
+        self.assertTrue(clipped.endswith("…"))
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience
+    unittest.main()

--- a/tests/test_presence_loop.py
+++ b/tests/test_presence_loop.py
@@ -1,0 +1,82 @@
+"""Tests for the ambient presence loop behaviour."""
+from __future__ import annotations
+
+import asyncio
+import time
+import unittest
+
+from engine.ambient_output import AmbientFragment, ComposeContext
+from engine.echo_logic import EchoChamber
+from engine.presence_loop import PresenceConfig, PresenceLoop
+
+
+class StubComposer:
+    """Minimal composer that records compose attempts."""
+
+    def __init__(self) -> None:
+        self.calls: list[ComposeContext] = []
+
+    async def compose(self, context: ComposeContext) -> AmbientFragment:
+        self.calls.append(context)
+        return AmbientFragment(text="silence", source="stub", metadata={})
+
+
+class StubDisplay:
+    """Display double capturing rendered fragments."""
+
+    def __init__(self) -> None:
+        self.fragments: list[AmbientFragment] = []
+
+    async def initialize(self) -> None:  # pragma: no cover - unused in tests
+        return None
+
+    async def shutdown(self) -> None:  # pragma: no cover - unused in tests
+        return None
+
+    async def render_fragment(self, fragment: AmbientFragment) -> None:
+        self.fragments.append(fragment)
+
+    async def emit_breath(self) -> None:  # pragma: no cover - unused in tests
+        return None
+
+    def capture_input(self) -> str:  # pragma: no cover - unused in tests
+        return ""
+
+
+class PresenceLoopSilenceCancellationTest(unittest.IsolatedAsyncioTestCase):
+    async def test_silence_response_cancelled_by_fresh_input(self) -> None:
+        composer = StubComposer()
+        display = StubDisplay()
+        echo = EchoChamber()
+        config = PresenceConfig(
+            min_delay=0.01,
+            max_delay=0.01,
+            silence_range=(0.2, 0.2),
+            poll_interval=0.01,
+            response_probability=0.0,
+            breath_interval=(1000.0, 1000.0),
+        )
+        loop = PresenceLoop(composer, echo, display, tts=None, config=config)
+
+        loop._next_breath = float("inf")  # prevent breath emissions during test
+        loop._last_input = time.monotonic() - 10.0
+        loop._silence_target = 0.0
+
+        await loop._process_events()  # schedule silence response
+        self.assertTrue(loop._silence_pending)
+
+        await loop._input_queue.put("hello")
+        await loop._process_events()  # process fresh input, cancelling silence
+        self.assertFalse(loop._silence_pending)
+
+        await asyncio.sleep(config.max_delay + 0.05)
+
+        for task in list(loop._pending_tasks):
+            await task
+
+        self.assertEqual([], display.fragments)
+        self.assertEqual([], composer.calls)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/ui/terminal_display.py
+++ b/ui/terminal_display.py
@@ -1,1 +1,62 @@
-# Terminal UI rendering and pacing logic
+"""Minimal terminal rendering for The Invitation."""
+from __future__ import annotations
+
+import asyncio
+import sys
+import textwrap
+import threading
+from datetime import datetime
+from typing import Optional
+
+from engine.ambient_output import AmbientFragment
+
+
+class TerminalDisplay:
+    """Handles all terminal IO while keeping the surface minimal."""
+
+    def __init__(self, stream=None) -> None:
+        self.stream = stream or sys.stdout
+        self._lock = threading.Lock()
+        self._start_time = datetime.now()
+
+    async def initialize(self) -> None:
+        message = (
+            "\n"
+            "(there is no prompt)\n"
+            "wait. type only if compelled.\n"
+        )
+        await self._write(message)
+
+    async def shutdown(self) -> None:
+        await self._write("\nclosing the field.\n")
+
+    async def render_fragment(self, fragment: AmbientFragment) -> None:
+        header = "\n"
+        body = self._format_text(fragment.text)
+        footer = "\n"
+        await self._write(header + body + footer)
+
+    async def emit_breath(self) -> None:
+        breath = "\u00b7"
+        await self._write(f"\r{breath}")
+        await asyncio.sleep(0.35)
+        await self._write("\r ")
+
+    def capture_input(self) -> Optional[str]:
+        try:
+            return sys.stdin.readline()
+        except Exception:
+            return None
+
+    # ------------------------------------------------------------------
+    def _format_text(self, text: str) -> str:
+        wrapped = textwrap.fill(text, width=68)
+        return wrapped
+
+    async def _write(self, text: str) -> None:
+        await asyncio.to_thread(self._write_sync, text)
+
+    def _write_sync(self, text: str) -> None:
+        with self._lock:
+            self.stream.write(text)
+            self.stream.flush()

--- a/voice/tts_interface.py
+++ b/voice/tts_interface.py
@@ -1,1 +1,46 @@
-# Optional TTS for ambient delivery
+"""Optional ambient text-to-speech support."""
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+try:
+    import importlib
+    _pyttsx3_spec = importlib.util.find_spec("pyttsx3")  # type: ignore[attr-defined]
+    if _pyttsx3_spec is not None:
+        import pyttsx3  # type: ignore
+    else:
+        pyttsx3 = None  # type: ignore
+except Exception:  # pragma: no cover - import failure fallback
+    pyttsx3 = None  # type: ignore
+
+
+class AmbientTTS:
+    """Thin wrapper around pyttsx3 if available."""
+
+    def __init__(self, enabled: bool = False, rate: int = 140) -> None:
+        self.enabled = enabled and pyttsx3 is not None
+        self._rate = rate
+        self._engine: Optional["pyttsx3.Engine"] = None
+
+    async def speak(self, text: str) -> None:
+        if not self.enabled or not text.strip():
+            return
+        await asyncio.to_thread(self._speak_sync, text)
+
+    # ------------------------------------------------------------------
+    def _ensure_engine(self) -> Optional["pyttsx3.Engine"]:
+        if pyttsx3 is None:
+            return None
+        if self._engine is None:
+            self._engine = pyttsx3.init()  # type: ignore[call-arg]
+            self._engine.setProperty("rate", self._rate)
+            self._engine.setProperty("volume", 0.6)
+        return self._engine
+
+    def _speak_sync(self, text: str) -> None:
+        engine = self._ensure_engine()
+        if engine is None:
+            return
+        engine.say(text)
+        engine.runAndWait()


### PR DESCRIPTION
## Summary
- implement asynchronous presence loop with silence, recursion, and ambient breath triggers
- compose ambient fragments from journals, invitation, and transcripts with optional Ollama integration and fallback
- add terminal UI surface and optional text-to-speech whisper support
- guard silence-triggered responses with monotonic tokens so resumed input cancels stale deliveries, and add regression coverage

## Testing
- python -m unittest discover -s tests -v

------
https://chatgpt.com/codex/tasks/task_e_68de2f92978083208f0f25d5809dc0ff